### PR TITLE
Add default `to` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,8 @@ OptimizeCssAssetsPlugin.prototype.print = function() {
   }
 };
 
-OptimizeCssAssetsPlugin.prototype.processCss = function(css) {
-  return this.options.cssProcessor.process(css, this.options.cssProcessorOptions); 
+OptimizeCssAssetsPlugin.prototype.processCss = function(css, assetName) {
+  return this.options.cssProcessor.process(css, Object.assign({ to: assetName }, this.options.cssProcessorOptions))); 
 };
 
 OptimizeCssAssetsPlugin.prototype.createCssAsset = function(css, originalAsset) {
@@ -65,7 +65,7 @@ OptimizeCssAssetsPlugin.prototype.apply = function(compiler) {
         
         var originalCss = asset.source();
         
-        var promise = self.processCss(originalCss); 
+        var promise = self.processCss(originalCss, assetName); 
         
         promise.then(
           function (result) {

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ OptimizeCssAssetsPlugin.prototype.print = function() {
 };
 
 OptimizeCssAssetsPlugin.prototype.processCss = function(css, assetName) {
-  return this.options.cssProcessor.process(css, Object.assign({ to: assetName }, this.options.cssProcessorOptions))); 
+  return this.options.cssProcessor.process(css, Object.assign({ to: assetName }, this.options.cssProcessorOptions)); 
 };
 
 OptimizeCssAssetsPlugin.prototype.createCssAsset = function(css, originalAsset) {


### PR DESCRIPTION
When I use this plugin to generate source map, it removed the source map path in the css file.

Before:

```css
#id{color:red}
/*# sourceMappingURL=my.css.map */
```

After I use this plugin:

```css
#id{color:red}
```

My config looks like this:

```js
var OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin')

module.exports = {
  devTool: 'source-map',
  plugins: [
    new OptimizeCSSPlugin({
      cssProcessorOptions: {
        map: { inline: false } // generate sourcemap use an external file
      }
    })
  ]
}
```
The [PostCSS document](https://github.com/postcss/postcss/blob/master/docs/source-maps.md) says:

> To ensure that you generate an accurate source map, you must indicate the input and output CSS file paths — using the options `from` and `to`, respectively.

So I add a default `to` option to keep source map path in the css file.