### PR TITLE
Enable safe flag by default in the docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ module.exports = {
     new OptimizeCssAssetsPlugin({
       assetNameRegExp: /\.optimize\.css$/g,
       cssProcessor: require('cssnano'),
-      cssProcessorOptions: { discardComments: { removeAll: true } },
+      cssProcessorOptions: { safe: true, discardComments: { removeAll: true } },
       canPrint: true
     })
   ]


### PR DESCRIPTION
When I added `optimize-css-assets-webpack-plugin` I noticed that some animations are not working. It turned out that:

- Default behavior of `cssnano` v3 is **unsafe.** Unused `@keyframes` are removed and `@keyframes` names are minified.
- We use code splitting.
- Therefore, each chunk of CSS assets is minified separately, causing name clashes. Many keyframe rules were renamed as `@keyframes a`

This PR makes the copy-and-paste example safer to use by default.