### PR TITLE
Option 'safe' is now a parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ module.exports = {
     new OptimizeCssAssetsPlugin({
       assetNameRegExp: /\.optimize\.css$/g,
       cssProcessor: require('cssnano'),
-      cssProcessorOptions: { safe: true, discardComments: { removeAll: true } },
+      cssProcessorOptions: { discardComments: { removeAll: true } },
       canPrint: true
     })
   ]


### PR DESCRIPTION
"Option safe was removed. Use parser: require("postcss-safe-parser")" in cssnano 4